### PR TITLE
Changed node.set to node.normal to fix the warning message from rspec.

### DIFF
--- a/spec/amazon_201509_remi_php55_spec.rb
+++ b/spec/amazon_201509_remi_php55_spec.rb
@@ -6,10 +6,10 @@ describe 'yum-remi-chef::remi-php55' do
       platform: 'amazon',
       version: '2015.09'
     ) do |node|
-      node.set['yum']['remi-php55']['enabled'] = true
-      node.set['yum']['remi-php55']['managed'] = true
-      node.set['yum']['remi-php55-debuginfo']['enabled'] = true
-      node.set['yum']['remi-php55-debuginfo']['managed'] = true
+      node.normal['yum']['remi-php55']['enabled'] = true
+      node.normal['yum']['remi-php55']['managed'] = true
+      node.normal['yum']['remi-php55-debuginfo']['enabled'] = true
+      node.normal['yum']['remi-php55-debuginfo']['managed'] = true
     end.converge(described_recipe)
   end
 

--- a/spec/amazon_201509_remi_php56_spec.rb
+++ b/spec/amazon_201509_remi_php56_spec.rb
@@ -6,10 +6,10 @@ describe 'yum-remi-chef::remi-php56' do
       platform: 'amazon',
       version: '2015.09'
     ) do |node|
-      node.set['yum']['remi-php56']['enabled'] = true
-      node.set['yum']['remi-php56']['managed'] = true
-      node.set['yum']['remi-php56-debuginfo']['enabled'] = true
-      node.set['yum']['remi-php56-debuginfo']['managed'] = true
+      node.normal['yum']['remi-php56']['enabled'] = true
+      node.normal['yum']['remi-php56']['managed'] = true
+      node.normal['yum']['remi-php56-debuginfo']['enabled'] = true
+      node.normal['yum']['remi-php56-debuginfo']['managed'] = true
     end.converge(described_recipe)
   end
 

--- a/spec/amazon_201509_remi_spec.rb
+++ b/spec/amazon_201509_remi_spec.rb
@@ -6,10 +6,10 @@ describe 'yum-remi-chef::remi' do
       platform: 'amazon',
       version: '2015.09'
     ) do |node|
-      node.set['yum']['remi']['enabled'] = true
-      node.set['yum']['remi']['managed'] = true
-      node.set['yum']['remi-debuginfo']['enabled'] = true
-      node.set['yum']['remi-debuginfo']['managed'] = true
+      node.normal['yum']['remi']['enabled'] = true
+      node.normal['yum']['remi']['managed'] = true
+      node.normal['yum']['remi-debuginfo']['enabled'] = true
+      node.normal['yum']['remi-debuginfo']['managed'] = true
     end.converge(described_recipe)
   end
 

--- a/spec/centos_58_remi_php55_spec.rb
+++ b/spec/centos_58_remi_php55_spec.rb
@@ -6,10 +6,10 @@ describe 'yum-remi-chef::remi-php55' do
       platform: 'centos',
       version: '5.8'
     ) do |node|
-      node.set['yum']['remi-php55']['enabled'] = true
-      node.set['yum']['remi-php55']['managed'] = true
-      node.set['yum']['remi-php55-debuginfo']['enabled'] = true
-      node.set['yum']['remi-php55-debuginfo']['managed'] = true
+      node.normal['yum']['remi-php55']['enabled'] = true
+      node.normal['yum']['remi-php55']['managed'] = true
+      node.normal['yum']['remi-php55-debuginfo']['enabled'] = true
+      node.normal['yum']['remi-php55-debuginfo']['managed'] = true
     end.converge('yum-remi-chef::remi-php55')
   end
 

--- a/spec/centos_58_remi_php56_spec.rb
+++ b/spec/centos_58_remi_php56_spec.rb
@@ -6,10 +6,10 @@ describe 'yum-remi-chef::remi-php56' do
       platform: 'centos',
       version: '5.8'
     ) do |node|
-      node.set['yum']['remi-php56']['enabled'] = true
-      node.set['yum']['remi-php56']['managed'] = true
-      node.set['yum']['remi-php56-debuginfo']['enabled'] = true
-      node.set['yum']['remi-php56-debuginfo']['managed'] = true
+      node.normal['yum']['remi-php56']['enabled'] = true
+      node.normal['yum']['remi-php56']['managed'] = true
+      node.normal['yum']['remi-php56-debuginfo']['enabled'] = true
+      node.normal['yum']['remi-php56-debuginfo']['managed'] = true
     end.converge(described_recipe)
   end
 

--- a/spec/centos_58_remi_spec.rb
+++ b/spec/centos_58_remi_spec.rb
@@ -6,10 +6,10 @@ describe 'yum-remi-chef::remi' do
       platform: 'centos',
       version: '5.8'
     ) do |node|
-      node.set['yum']['remi']['enabled'] = true
-      node.set['yum']['remi']['managed'] = true
-      node.set['yum']['remi-debuginfo']['enabled'] = true
-      node.set['yum']['remi-debuginfo']['managed'] = true
+      node.normal['yum']['remi']['enabled'] = true
+      node.normal['yum']['remi']['managed'] = true
+      node.normal['yum']['remi-debuginfo']['enabled'] = true
+      node.normal['yum']['remi-debuginfo']['managed'] = true
     end.converge(described_recipe)
   end
 

--- a/spec/centos_65_remi_php55_spec.rb
+++ b/spec/centos_65_remi_php55_spec.rb
@@ -6,10 +6,10 @@ describe 'yum-remi-chef::remi-php55' do
       platform: 'centos',
       version: '6.5'
     ) do |node|
-      node.set['yum']['remi-php55']['enabled'] = true
-      node.set['yum']['remi-php55']['managed'] = true
-      node.set['yum']['remi-php55-debuginfo']['enabled'] = true
-      node.set['yum']['remi-php55-debuginfo']['managed'] = true
+      node.normal['yum']['remi-php55']['enabled'] = true
+      node.normal['yum']['remi-php55']['managed'] = true
+      node.normal['yum']['remi-php55-debuginfo']['enabled'] = true
+      node.normal['yum']['remi-php55-debuginfo']['managed'] = true
     end.converge(described_recipe)
   end
 

--- a/spec/centos_65_remi_php56_spec.rb
+++ b/spec/centos_65_remi_php56_spec.rb
@@ -6,10 +6,10 @@ describe 'yum-remi-chef::remi-php56' do
       platform: 'centos',
       version: '6.5'
     ) do |node|
-      node.set['yum']['remi-php56']['enabled'] = true
-      node.set['yum']['remi-php56']['managed'] = true
-      node.set['yum']['remi-php56-debuginfo']['enabled'] = true
-      node.set['yum']['remi-php56-debuginfo']['managed'] = true
+      node.normal['yum']['remi-php56']['enabled'] = true
+      node.normal['yum']['remi-php56']['managed'] = true
+      node.normal['yum']['remi-php56-debuginfo']['enabled'] = true
+      node.normal['yum']['remi-php56-debuginfo']['managed'] = true
     end.converge(described_recipe)
   end
 

--- a/spec/centos_65_remi_php70_spec.rb
+++ b/spec/centos_65_remi_php70_spec.rb
@@ -6,10 +6,10 @@ describe 'yum-remi-chef::remi-php70' do
       platform: 'centos',
       version: '6.5'
     ) do |node|
-      node.set['yum']['remi-php70']['enabled'] = true
-      node.set['yum']['remi-php70']['managed'] = true
-      node.set['yum']['remi-php70-debuginfo']['enabled'] = true
-      node.set['yum']['remi-php70-debuginfo']['managed'] = true
+      node.normal['yum']['remi-php70']['enabled'] = true
+      node.normal['yum']['remi-php70']['managed'] = true
+      node.normal['yum']['remi-php70-debuginfo']['enabled'] = true
+      node.normal['yum']['remi-php70-debuginfo']['managed'] = true
     end.converge(described_recipe)
   end
 

--- a/spec/centos_65_remi_spec.rb
+++ b/spec/centos_65_remi_spec.rb
@@ -6,10 +6,10 @@ describe 'yum-remi-chef::remi' do
       platform: 'centos',
       version: '6.5'
     ) do |node|
-      node.set['yum']['remi']['enabled'] = true
-      node.set['yum']['remi']['managed'] = true
-      node.set['yum']['remi-debuginfo']['enabled'] = true
-      node.set['yum']['remi-debuginfo']['managed'] = true
+      node.normal['yum']['remi']['enabled'] = true
+      node.normal['yum']['remi']['managed'] = true
+      node.normal['yum']['remi-debuginfo']['enabled'] = true
+      node.normal['yum']['remi-debuginfo']['managed'] = true
     end.converge(described_recipe)
   end
 

--- a/spec/centos_70_remi_php55_spec.rb
+++ b/spec/centos_70_remi_php55_spec.rb
@@ -6,10 +6,10 @@ describe 'yum-remi-chef::remi-php55' do
       platform: 'centos',
       version: '7.0'
     ) do |node|
-      node.set['yum']['remi-php55']['enabled'] = true
-      node.set['yum']['remi-php55']['managed'] = true
-      node.set['yum']['remi-php55-debuginfo']['enabled'] = true
-      node.set['yum']['remi-php55-debuginfo']['managed'] = true
+      node.normal['yum']['remi-php55']['enabled'] = true
+      node.normal['yum']['remi-php55']['managed'] = true
+      node.normal['yum']['remi-php55-debuginfo']['enabled'] = true
+      node.normal['yum']['remi-php55-debuginfo']['managed'] = true
     end.converge(described_recipe)
   end
 

--- a/spec/centos_70_remi_php56_spec.rb
+++ b/spec/centos_70_remi_php56_spec.rb
@@ -6,10 +6,10 @@ describe 'yum-remi-chef::remi-php56' do
       platform: 'centos',
       version: '7.0'
     ) do |node|
-      node.set['yum']['remi-php56']['enabled'] = true
-      node.set['yum']['remi-php56']['managed'] = true
-      node.set['yum']['remi-php56-debuginfo']['enabled'] = true
-      node.set['yum']['remi-php56-debuginfo']['managed'] = true
+      node.normal['yum']['remi-php56']['enabled'] = true
+      node.normal['yum']['remi-php56']['managed'] = true
+      node.normal['yum']['remi-php56-debuginfo']['enabled'] = true
+      node.normal['yum']['remi-php56-debuginfo']['managed'] = true
     end.converge(described_recipe)
   end
 

--- a/spec/centos_70_remi_php70_spec.rb
+++ b/spec/centos_70_remi_php70_spec.rb
@@ -6,10 +6,10 @@ describe 'yum-remi-chef::remi-php70' do
       platform: 'centos',
       version: '7.0'
     ) do |node|
-      node.set['yum']['remi-php70']['enabled'] = true
-      node.set['yum']['remi-php70']['managed'] = true
-      node.set['yum']['remi-php70-debuginfo']['enabled'] = true
-      node.set['yum']['remi-php70-debuginfo']['managed'] = true
+      node.normal['yum']['remi-php70']['enabled'] = true
+      node.normal['yum']['remi-php70']['managed'] = true
+      node.normal['yum']['remi-php70-debuginfo']['enabled'] = true
+      node.normal['yum']['remi-php70-debuginfo']['managed'] = true
     end.converge(described_recipe)
   end
 

--- a/spec/centos_70_remi_spec.rb
+++ b/spec/centos_70_remi_spec.rb
@@ -6,10 +6,10 @@ describe 'yum-remi-chef::remi' do
       platform: 'centos',
       version: '7.0'
     ) do |node|
-      node.set['yum']['remi']['enabled'] = true
-      node.set['yum']['remi']['managed'] = true
-      node.set['yum']['remi-debuginfo']['enabled'] = true
-      node.set['yum']['remi-debuginfo']['managed'] = true
+      node.normal['yum']['remi']['enabled'] = true
+      node.normal['yum']['remi']['managed'] = true
+      node.normal['yum']['remi-debuginfo']['enabled'] = true
+      node.normal['yum']['remi-debuginfo']['managed'] = true
     end.converge(described_recipe)
   end
 


### PR DESCRIPTION
### Description

Removes deprecation warnings from rspec tests.
The warning message is as follows: ```WARN: node.set is deprecated and will be removed in Chef 14, please use node.default/node.override (or node.normal only if you really need persistence)```.

### Issues Resolved

No existing issues.

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD