### PR TITLE
Changed from using baseurl to mirrorlist.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The following attributes are set by default
 
 ```ruby
 default['yum']['remi']['repositoryid'] = 'remi'
-default['yum']['remi']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/remi/$basearch/'
+default['yum']['remi']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/5/remi/mirror'
 default['yum']['remi']['description'] = "Remi's RPM repository for Enterprise Linux 5 - $basearch"
 default['yum']['remi']['enabled'] = true
 default['yum']['remi']['gpgcheck'] = true
@@ -50,7 +50,7 @@ default['yum']['remi']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-remi'
 
 ```ruby
 default['yum']['remi-php55']['repositoryid'] = 'remi-php55'
-default['yum']['remi-php55']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/php55/$basearch/'
+default['yum']['remi-php55']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/5/php55/mirror'
 default['yum']['remi-php55']['description'] = "Remi's PHP 5.5 RPM repository for Enterprise Linux 5 - $basearch"
 default['yum']['remi-php55']['enabled'] = true
 default['yum']['remi-php55']['gpgcheck'] = true
@@ -59,7 +59,7 @@ default['yum']['remi-php55']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-r
 
 ```ruby
 default['yum']['remi-php56']['repositoryid'] = 'remi-php56'
-default['yum']['remi-php56']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/php56/$basearch/'
+default['yum']['remi-php56']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/5/php56/mirror'
 default['yum']['remi-php56']['description'] = "Remi's PHP 5.6 RPM repository for Enterprise Linux 5 - $basearch"
 default['yum']['remi-php56']['enabled'] = true
 default['yum']['remi-php56']['gpgcheck'] = true
@@ -69,7 +69,7 @@ default['yum']['remi-php56']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-r
 ```ruby
 default['yum']['remi-php70']['managed'] = true
 default['yum']['remi-php70']['repositoryid'] = 'remi-php70'
-default['yum']['remi-php70']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/php70/$basearch/'
+default['yum']['remi-php70']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/6/php70/mirror'
 default['yum']['remi-php70']['description'] = "Remi's PHP 7.0 RPM repository for Enterprise Linux 6 - $basearch"
 default['yum']['remi-php70']['enabled'] = true
 default['yum']['remi-php70']['gpgcheck'] = true
@@ -83,7 +83,7 @@ default['yum']['remi-php70']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-r
 
 ```ruby
   yum_repository 'remi' do
-    baseurl 'http://rpms.remirepo.net/enterprise/6/remi/$basearch/'
+    mirrorlist 'http://rpms.remirepo.net/enterprise/6/remi/mirror'
     description "Remi's RPM repository for Enterprise Linux 6 - $basearch"
     enabled true
     gpgcheck true

--- a/attributes/remi-php55.rb
+++ b/attributes/remi-php55.rb
@@ -6,18 +6,22 @@ default['yum']['remi-php55']['managed'] = true
 
 case node['platform']
 when 'fedora'
-  default['yum']['remi-php55']['baseurl'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/php55/$basearch/"
+  # default['yum']['remi-php55']['baseurl'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/php55/$basearch/"
+  default['yum']['remi-php55']['mirrorlist'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/php55/mirror"
   default['yum']['remi-php55']['description'] = "Remi's PHP 5.5 RPM repository for Fedora Linux #{node['platform_version'].to_i} - $basearch"
 else
   case node['platform_version'].to_i
   when 5
-    default['yum']['remi-php55']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/php55/$basearch/'
+    # default['yum']['remi-php55']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/php55/$basearch/'
+    default['yum']['remi-php55']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/5/php55/mirror'
     default['yum']['remi-php55']['description'] = "Remi's PHP 5.5 RPM repository for Enterprise Linux 5 - $basearch"
   when 6, 2013, 2014, 2015
-    default['yum']['remi-php55']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/php55/$basearch/'
+    # default['yum']['remi-php55']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/php55/$basearch/'
+    default['yum']['remi-php55']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/6/php55/mirror'
     default['yum']['remi-php55']['description'] = "Remi's PHP 5.5 RPM repository for Enterprise Linux 6 - $basearch"
   when 7
-    default['yum']['remi-php55']['baseurl'] = 'http://rpms.remirepo.net/enterprise/7/php55/$basearch/'
+    # default['yum']['remi-php55']['baseurl'] = 'http://rpms.remirepo.net/enterprise/7/php55/$basearch/'
+    default['yum']['remi-php55']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/7/php55/mirror'
     default['yum']['remi-php55']['description'] = "Remi's PHP 5.5 RPM repository for Enterprise Linux 7 - $basearch"
   end
 end

--- a/attributes/remi-php56.rb
+++ b/attributes/remi-php56.rb
@@ -6,18 +6,22 @@ default['yum']['remi-php56']['managed'] = true
 
 case node['platform']
 when 'fedora'
-  default['yum']['remi-php56']['baseurl'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/php56/$basearch/"
+  # default['yum']['remi-php56']['baseurl'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/php56/$basearch/"
+  default['yum']['remi-php56']['mirrorlist'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/php56/mirror"
   default['yum']['remi-php56']['description'] = "Remi's PHP 5.6 RPM repository for Fedora Linux #{node['platform_version'].to_i} - $basearch"
 else
   case node['platform_version'].to_i
   when 5
-    default['yum']['remi-php56']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/php56/$basearch/'
+    # default['yum']['remi-php56']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/php56/$basearch/'
+    default['yum']['remi-php56']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/5/php56/mirror'
     default['yum']['remi-php56']['description'] = "Remi's PHP 5.6 RPM repository for Enterprise Linux 5 - $basearch"
   when 6, 2013, 2014, 2015, 2016
-    default['yum']['remi-php56']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/php56/$basearch/'
+    # default['yum']['remi-php56']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/php56/$basearch/'
+    default['yum']['remi-php56']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/6/php56/mirror'
     default['yum']['remi-php56']['description'] = "Remi's PHP 5.6 RPM repository for Enterprise Linux 6 - $basearch"
   when 7
-    default['yum']['remi-php56']['baseurl'] = 'http://rpms.remirepo.net/enterprise/7/php56/$basearch/'
+    # default['yum']['remi-php56']['baseurl'] = 'http://rpms.remirepo.net/enterprise/7/php56/$basearch/'
+    default['yum']['remi-php56']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/7/php56/mirror'
     default['yum']['remi-php56']['description'] = "Remi's PHP 5.6 RPM repository for Enterprise Linux 7 - $basearch"
   end
 end

--- a/attributes/remi-php70.rb
+++ b/attributes/remi-php70.rb
@@ -6,18 +6,22 @@ default['yum']['remi-php70']['managed'] = true
 
 case node['platform']
 when 'fedora'
-  default['yum']['remi-php70']['baseurl'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/php70/$basearch/"
+  # default['yum']['remi-php70']['baseurl'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/php70/$basearch/"
+  default['yum']['remi-php70']['mirrorlist'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/php70/mirror"
   default['yum']['remi-php70']['description'] = "Remi's PHP 7.0 RPM repository for Fedora Linux #{node['platform_version'].to_i} - $basearch"
 else
   case node['platform_version'].to_i
   when 5
-    default['yum']['remi-php70']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/php70/$basearch/'
+    # default['yum']['remi-php70']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/php70/$basearch/'
+    default['yum']['remi-php70']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/5/php70/mirror'
     default['yum']['remi-php70']['description'] = "Remi's PHP 7.0 RPM repository for Enterprise Linux 5 - $basearch"
   when 6, 2013, 2014, 2015, 2016
-    default['yum']['remi-php70']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/php70/$basearch/'
+    # default['yum']['remi-php70']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/php70/$basearch/'
+    default['yum']['remi-php70']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/6/php70/mirror'
     default['yum']['remi-php70']['description'] = "Remi's PHP 7.0 RPM repository for Enterprise Linux 6 - $basearch"
   when 7
-    default['yum']['remi-php70']['baseurl'] = 'http://rpms.remirepo.net/enterprise/7/php70/$basearch/'
+    # default['yum']['remi-php70']['baseurl'] = 'http://rpms.remirepo.net/enterprise/7/php70/$basearch/'
+    default['yum']['remi-php70']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/7/php70/mirror'
     default['yum']['remi-php70']['description'] = "Remi's PHP 7.0 RPM repository for Enterprise Linux 7 - $basearch"
   end
 end

--- a/attributes/remi-test.rb
+++ b/attributes/remi-test.rb
@@ -6,18 +6,22 @@ default['yum']['remi-test']['managed'] = false
 
 case node['platform']
 when 'fedora'
-  default['yum']['remi-test']['baseurl'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/remi-test/$basearch/"
+  # default['yum']['remi-test']['baseurl'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/remi-test/$basearch/"
+  default['yum']['remi-test']['mirrorlist'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/remi-test/mirror"
   default['yum']['remi-test']['description'] = "Remi's test RPM repository for Fedora Linux #{node['platform_version'].to_i} - $basearch"
 else
   case node['platform_version'].to_i
   when 5
-    default['yum']['remi-test']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/remi-test/$basearch/'
+    # default['yum']['remi-test']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/remi-test/$basearch/'
+    default['yum']['remi-test']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/5/remi-test/mirror'
     default['yum']['remi-test']['description'] = "Remi's test RPM repository for Enterprise Linux 5 - $basearch"
   when 6, 2013, 2014, 2015, 2016
-    default['yum']['remi-test']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/remi-test/$basearch/'
+    # default['yum']['remi-test']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/remi-test/$basearch/'
+    default['yum']['remi-test']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/6/remi-test/mirror'
     default['yum']['remi-test']['description'] = "Remi's test RPM repository for Enterprise Linux 6 - $basearch"
   when 7
-    default['yum']['remi-test']['baseurl'] = 'http://rpms.remirepo.net/enterprise/7/remi-test/$basearch/'
+    # default['yum']['remi-test']['baseurl'] = 'http://rpms.remirepo.net/enterprise/7/remi-test/$basearch/'
+    default['yum']['remi-test']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/7/remi-test/mirror'
     default['yum']['remi-test']['description'] = "Remi's test RPM repository for Enterprise Linux 7 - $basearch"
   end
 end

--- a/attributes/remi.rb
+++ b/attributes/remi.rb
@@ -6,18 +6,22 @@ default['yum']['remi']['managed'] = true
 
 case node['platform']
 when 'fedora'
-  default['yum']['remi']['baseurl'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/remi/$basearch/"
+  # default['yum']['remi']['baseurl'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/remi/$basearch/"
+  default['yum']['remi']['mirrorlist'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/remi/mirror"
   default['yum']['remi']['description'] = "Remi's RPM repository for Fedora Linux #{node['platform_version'].to_i} - $basearch"
 else
   case node['platform_version'].to_i
   when 5
-    default['yum']['remi']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/remi/$basearch/'
+    # default['yum']['remi']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/remi/$basearch/'
+    default['yum']['remi']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/5/remi/mirror'
     default['yum']['remi']['description'] = "Remi's RPM repository for Enterprise Linux 5 - $basearch"
   when 6, 2013, 2014, 2015, 2016
-    default['yum']['remi']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/remi/$basearch/'
+    # default['yum']['remi']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/remi/$basearch/'
+    default['yum']['remi']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/6/remi/mirror'
     default['yum']['remi']['description'] = "Remi's RPM repository for Enterprise Linux 6 - $basearch"
   when 7
-    default['yum']['remi']['baseurl'] = 'http://rpms.remirepo.net/enterprise/7/remi/$basearch/'
+    # default['yum']['remi']['baseurl'] = 'http://rpms.remirepo.net/enterprise/7/remi/$basearch/'
+    default['yum']['remi']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/7/remi/mirror'
     default['yum']['remi']['description'] = "Remi's RPM repository for Enterprise Linux 7 - $basearch"
   end
 end


### PR DESCRIPTION
### Description

Change from using ```baseurl``` to ```mirrorlist```. This is to relieve stress from the remirepo.net domain.

### Issues Resolved

No existing issues.

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


