### PR TITLE
Change test install package from php to php-cli.

### DIFF
--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -1,1 +1,1 @@
-package 'php'
+package 'php-cli'


### PR DESCRIPTION
### Description

The "php" package tends to bring in unnecessary side dependencies, such as http, etc.
"php-cli" will install only php and what's necessary to get it working from the CLI.
This should fix the problems with centos-5 tests.

### Issues Resolved

No existing issues.

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD