### PR TITLE
amazon linux 2016 support for remi-php55 and remi-php56-debuginfo

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -69,4 +69,4 @@ suites:
         enabled: true
         managed: true
   excludes:
-  - centos-5
+  - centos-5.11

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ services: docker
 
 env:
   matrix:
-  - INSTANCE=remi-centos-5
   - INSTANCE=remi-centos-6
   - INSTANCE=remi-centos-7
   - INSTANCE=remi-fedora-latest

--- a/attributes/remi-debuginfo.rb
+++ b/attributes/remi-debuginfo.rb
@@ -8,16 +8,11 @@ case node['platform']
 when 'fedora'
   default['yum']['remi-debuginfo']['baseurl'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/debug-remi/$basearch/"
   default['yum']['remi-debuginfo']['description'] = "Remi's RPM repository for Fedora Linux #{node['platform_version'].to_i} - $basearch - debuginfo"
+when 'amazon'
+  # Default to EL6
+  default['yum']['remi-debuginfo']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/debug-remi/$basearch/'
+  default['yum']['remi-debuginfo']['description'] = "Remi's RPM repository for Enterprise Linux 6 - $basearch - debuginfo"
 else
-  case node['platform_version'].to_i
-  when 5
-    default['yum']['remi-debuginfo']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/debug-remi/$basearch/'
-    default['yum']['remi-debuginfo']['description'] = "Remi's RPM repository for Enterprise Linux 5 - $basearch - debuginfo"
-  when 6, 2013, 2014, 2015, 2016
-    default['yum']['remi-debuginfo']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/debug-remi/$basearch/'
-    default['yum']['remi-debuginfo']['description'] = "Remi's RPM repository for Enterprise Linux 6 - $basearch - debuginfo"
-  when 7
-    default['yum']['remi-debuginfo']['baseurl'] = 'http://rpms.remirepo.net/enterprise/7/debug-remi/$basearch/'
-    default['yum']['remi-debuginfo']['description'] = "Remi's RPM repository for Enterprise Linux 7 - $basearch - debuginfo"
-  end
+  default['yum']['remi-debuginfo']['baseurl'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/debug-remi/$basearch/"
+  default['yum']['remi-debuginfo']['description'] = "Remi's RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch - debuginfo"
 end

--- a/attributes/remi-php55-debuginfo.rb
+++ b/attributes/remi-php55-debuginfo.rb
@@ -8,16 +8,11 @@ case node['platform']
 when 'fedora'
   default['yum']['remi-php55-debuginfo']['baseurl'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/debug-php55/$basearch/"
   default['yum']['remi-php55-debuginfo']['description'] = "Remi's PHP 5.5 RPM repository for Fedora Linux #{node['platform_version'].to_i} - $basearch - debuginfo"
+when 'amazon'
+  # Default to EL6
+  default['yum']['remi-php55-debuginfo']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/debug-php55/$basearch/'
+  default['yum']['remi-php55-debuginfo']['description'] = "Remi's PHP 5.5 RPM repository for Enterprise Linux 6 - $basearch - debuginfo"
 else
-  case node['platform_version'].to_i
-  when 5
-    default['yum']['remi-php55-debuginfo']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/debug-php55/$basearch/'
-    default['yum']['remi-php55-debuginfo']['description'] = "Remi's PHP 5.5 RPM repository for Enterprise Linux 5 - $basearch - debuginfo"
-  when 6, 2013, 2014, 2015, 2016
-    default['yum']['remi-php55-debuginfo']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/debug-php55/$basearch/'
-    default['yum']['remi-php55-debuginfo']['description'] = "Remi's PHP 5.5 RPM repository for Enterprise Linux 6 - $basearch - debuginfo"
-  when 7
-    default['yum']['remi-php55-debuginfo']['baseurl'] = 'http://rpms.remirepo.net/enterprise/7/debug-php55/$basearch/'
-    default['yum']['remi-php55-debuginfo']['description'] = "Remi's PHP 5.5 RPM repository for Enterprise Linux 7 - $basearch - debuginfo"
-  end
+  default['yum']['remi-php55-debuginfo']['baseurl'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/debug-php55/$basearch/"
+  default['yum']['remi-php55-debuginfo']['description'] = "Remi's PHP 5.5 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch - debuginfo"
 end

--- a/attributes/remi-php55.rb
+++ b/attributes/remi-php55.rb
@@ -9,19 +9,13 @@ when 'fedora'
   # default['yum']['remi-php55']['baseurl'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/php55/$basearch/"
   default['yum']['remi-php55']['mirrorlist'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/php55/mirror"
   default['yum']['remi-php55']['description'] = "Remi's PHP 5.5 RPM repository for Fedora Linux #{node['platform_version'].to_i} - $basearch"
+when 'amazon'
+  # Default to EL6
+  # default['yum']['remi-php55']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/php55/$basearch/'
+  default['yum']['remi-php55']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/6/php55/mirror'
+  default['yum']['remi-php55']['description'] = "Remi's PHP 5.5 RPM repository for Enterprise Linux 6 - $basearch"
 else
-  case node['platform_version'].to_i
-  when 5
-    # default['yum']['remi-php55']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/php55/$basearch/'
-    default['yum']['remi-php55']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/5/php55/mirror'
-    default['yum']['remi-php55']['description'] = "Remi's PHP 5.5 RPM repository for Enterprise Linux 5 - $basearch"
-  when 6, 2013, 2014, 2015
-    # default['yum']['remi-php55']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/php55/$basearch/'
-    default['yum']['remi-php55']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/6/php55/mirror'
-    default['yum']['remi-php55']['description'] = "Remi's PHP 5.5 RPM repository for Enterprise Linux 6 - $basearch"
-  when 7
-    # default['yum']['remi-php55']['baseurl'] = 'http://rpms.remirepo.net/enterprise/7/php55/$basearch/'
-    default['yum']['remi-php55']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/7/php55/mirror'
-    default['yum']['remi-php55']['description'] = "Remi's PHP 5.5 RPM repository for Enterprise Linux 7 - $basearch"
-  end
+  # default['yum']['remi-php55']['baseurl'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/php55/$basearch/"
+  default['yum']['remi-php55']['mirrorlist'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/php55/mirror"
+  default['yum']['remi-php55']['description'] = "Remi's PHP 5.5 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
 end

--- a/attributes/remi-php56-debuginfo.rb
+++ b/attributes/remi-php56-debuginfo.rb
@@ -8,16 +8,11 @@ case node['platform']
 when 'fedora'
   default['yum']['remi-php56-debuginfo']['baseurl'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/debug-php56/$basearch/"
   default['yum']['remi-php56-debuginfo']['description'] = "Remi's PHP 5.6 RPM repository for Fedora Linux #{node['platform_version'].to_i} - $basearch - debuginfo"
+when 'amazon'
+  # Default to EL 6
+  default['yum']['remi-php56-debuginfo']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/debug-php56/$basearch/'
+  default['yum']['remi-php56-debuginfo']['description'] = "Remi's PHP 5.6 RPM repository for Enterprise Linux 6 - $basearch - debuginfo"
 else
-  case node['platform_version'].to_i
-  when 5
-    default['yum']['remi-php56-debuginfo']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/debug-php56/$basearch/'
-    default['yum']['remi-php56-debuginfo']['description'] = "Remi's PHP 5.6 RPM repository for Enterprise Linux 5 - $basearch - debuginfo"
-  when 6, 2013, 2014, 2015
-    default['yum']['remi-php56-debuginfo']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/debug-php56/$basearch/'
-    default['yum']['remi-php56-debuginfo']['description'] = "Remi's PHP 5.6 RPM repository for Enterprise Linux 6 - $basearch - debuginfo"
-  when 7
-    default['yum']['remi-php56-debuginfo']['baseurl'] = 'http://rpms.remirepo.net/enterprise/7/debug-php56/$basearch/'
-    default['yum']['remi-php56-debuginfo']['description'] = "Remi's PHP 5.6 RPM repository for Enterprise Linux 7 - $basearch - debuginfo"
-  end
+  default['yum']['remi-php56-debuginfo']['baseurl'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/debug-php56/$basearch/"
+  default['yum']['remi-php56-debuginfo']['description'] = "Remi's PHP 5.6 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch - debuginfo"
 end

--- a/attributes/remi-php56.rb
+++ b/attributes/remi-php56.rb
@@ -9,19 +9,13 @@ when 'fedora'
   # default['yum']['remi-php56']['baseurl'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/php56/$basearch/"
   default['yum']['remi-php56']['mirrorlist'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/php56/mirror"
   default['yum']['remi-php56']['description'] = "Remi's PHP 5.6 RPM repository for Fedora Linux #{node['platform_version'].to_i} - $basearch"
+when 'amazon'
+  # Default to EL6
+  # default['yum']['remi-php56']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/php56/$basearch/'
+  default['yum']['remi-php56']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/6/php56/mirror'
+  default['yum']['remi-php56']['description'] = "Remi's PHP 5.6 RPM repository for Enterprise Linux 6 - $basearch"
 else
-  case node['platform_version'].to_i
-  when 5
-    # default['yum']['remi-php56']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/php56/$basearch/'
-    default['yum']['remi-php56']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/5/php56/mirror'
-    default['yum']['remi-php56']['description'] = "Remi's PHP 5.6 RPM repository for Enterprise Linux 5 - $basearch"
-  when 6, 2013, 2014, 2015, 2016
-    # default['yum']['remi-php56']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/php56/$basearch/'
-    default['yum']['remi-php56']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/6/php56/mirror'
-    default['yum']['remi-php56']['description'] = "Remi's PHP 5.6 RPM repository for Enterprise Linux 6 - $basearch"
-  when 7
-    # default['yum']['remi-php56']['baseurl'] = 'http://rpms.remirepo.net/enterprise/7/php56/$basearch/'
-    default['yum']['remi-php56']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/7/php56/mirror'
-    default['yum']['remi-php56']['description'] = "Remi's PHP 5.6 RPM repository for Enterprise Linux 7 - $basearch"
-  end
+  # default['yum']['remi-php56']['baseurl'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/php56/$basearch/"
+  default['yum']['remi-php56']['mirrorlist'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/php56/mirror"
+  default['yum']['remi-php56']['description'] = "Remi's PHP 5.6 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
 end

--- a/attributes/remi-php70-debuginfo.rb
+++ b/attributes/remi-php70-debuginfo.rb
@@ -8,16 +8,11 @@ case node['platform']
 when 'fedora'
   default['yum']['remi-php70-debuginfo']['baseurl'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/debug-php70/$basearch/"
   default['yum']['remi-php70-debuginfo']['description'] = "Remi's PHP 7.0 RPM repository for Fedora Linux #{node['platform_version'].to_i} - $basearch - debuginfo"
+when 'amazon'
+  # Default to EL6
+  default['yum']['remi-php70-debuginfo']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/debug-php70/$basearch/'
+  default['yum']['remi-php70-debuginfo']['description'] = "Remi's PHP 7.0 RPM repository for Enterprise Linux 6 - $basearch - debuginfo"
 else
-  case node['platform_version'].to_i
-  when 5
-    default['yum']['remi-php70-debuginfo']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/debug-php70/$basearch/'
-    default['yum']['remi-php70-debuginfo']['description'] = "Remi's PHP 7.0 RPM repository for Enterprise Linux 5 - $basearch - debuginfo"
-  when 6, 2013, 2014, 2015, 2016
-    default['yum']['remi-php70-debuginfo']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/debug-php70/$basearch/'
-    default['yum']['remi-php70-debuginfo']['description'] = "Remi's PHP 7.0 RPM repository for Enterprise Linux 6 - $basearch - debuginfo"
-  when 7
-    default['yum']['remi-php70-debuginfo']['baseurl'] = 'http://rpms.remirepo.net/enterprise/7/debug-php70/$basearch/'
-    default['yum']['remi-php70-debuginfo']['description'] = "Remi's PHP 7.0 RPM repository for Enterprise Linux 7 - $basearch - debuginfo"
-  end
+  default['yum']['remi-php70-debuginfo']['baseurl'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/debug-php70/$basearch/"
+  default['yum']['remi-php70-debuginfo']['description'] = "Remi's PHP 7.0 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch - debuginfo"
 end

--- a/attributes/remi-php70.rb
+++ b/attributes/remi-php70.rb
@@ -9,19 +9,13 @@ when 'fedora'
   # default['yum']['remi-php70']['baseurl'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/php70/$basearch/"
   default['yum']['remi-php70']['mirrorlist'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/php70/mirror"
   default['yum']['remi-php70']['description'] = "Remi's PHP 7.0 RPM repository for Fedora Linux #{node['platform_version'].to_i} - $basearch"
+when 'amazon'
+  # Default to EL6
+  # default['yum']['remi-php70']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/php70/$basearch/'
+  default['yum']['remi-php70']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/6/php70/mirror'
+  default['yum']['remi-php70']['description'] = "Remi's PHP 7.0 RPM repository for Enterprise Linux 6 - $basearch"
 else
-  case node['platform_version'].to_i
-  when 5
-    # default['yum']['remi-php70']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/php70/$basearch/'
-    default['yum']['remi-php70']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/5/php70/mirror'
-    default['yum']['remi-php70']['description'] = "Remi's PHP 7.0 RPM repository for Enterprise Linux 5 - $basearch"
-  when 6, 2013, 2014, 2015, 2016
-    # default['yum']['remi-php70']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/php70/$basearch/'
-    default['yum']['remi-php70']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/6/php70/mirror'
-    default['yum']['remi-php70']['description'] = "Remi's PHP 7.0 RPM repository for Enterprise Linux 6 - $basearch"
-  when 7
-    # default['yum']['remi-php70']['baseurl'] = 'http://rpms.remirepo.net/enterprise/7/php70/$basearch/'
-    default['yum']['remi-php70']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/7/php70/mirror'
-    default['yum']['remi-php70']['description'] = "Remi's PHP 7.0 RPM repository for Enterprise Linux 7 - $basearch"
-  end
+  # default['yum']['remi-php70']['baseurl'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/php70/$basearch/"
+  default['yum']['remi-php70']['mirrorlist'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/php70/mirror"
+  default['yum']['remi-php70']['description'] = "Remi's PHP 7.0 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
 end

--- a/attributes/remi-test-debuginfo.rb
+++ b/attributes/remi-test-debuginfo.rb
@@ -8,16 +8,11 @@ case node['platform']
 when 'fedora'
   default['yum']['remi-test']['baseurl'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/debug-remi-test/$basearch/"
   default['yum']['remi-test']['description'] = "Remi's test RPM repository for Fedora Linux #{node['platform_version'].to_i} - $basearch - debuginfo"
+when 'amazon'
+  # Default to EL6
+  default['yum']['remi-test']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/debug-remi-test/$basearch/'
+  default['yum']['remi-test']['description'] = "Remi's test RPM repository for Enterprise Linux 6 - $basearch - debuginfo"
 else
-  case node['platform_version'].to_i
-  when 5
-    default['yum']['remi-test']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/debug-remi-test/$basearch/'
-    default['yum']['remi-test']['description'] = "Remi's test RPM repository for Enterprise Linux 5 - $basearch - debuginfo"
-  when 6, 2013, 2014, 2015
-    default['yum']['remi-test']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/debug-remi-test/$basearch/'
-    default['yum']['remi-test']['description'] = "Remi's test RPM repository for Enterprise Linux 6 - $basearch - debuginfo"
-  when 7
-    default['yum']['remi-test']['baseurl'] = 'http://rpms.remirepo.net/enterprise/7/debug-remi-test/$basearch/'
-    default['yum']['remi-test']['description'] = "Remi's test RPM repository for Enterprise Linux 7 - $basearch - debuginfo"
-  end
+  default['yum']['remi-test']['baseurl'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/debug-remi-test/$basearch/"
+  default['yum']['remi-test']['description'] = "Remi's test RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch - debuginfo"
 end

--- a/attributes/remi-test.rb
+++ b/attributes/remi-test.rb
@@ -9,19 +9,13 @@ when 'fedora'
   # default['yum']['remi-test']['baseurl'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/remi-test/$basearch/"
   default['yum']['remi-test']['mirrorlist'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/remi-test/mirror"
   default['yum']['remi-test']['description'] = "Remi's test RPM repository for Fedora Linux #{node['platform_version'].to_i} - $basearch"
+when 'amazon'
+  # Default to EL6
+  # default['yum']['remi-test']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/remi-test/$basearch/'
+  default['yum']['remi-test']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/6/remi-test/mirror'
+  default['yum']['remi-test']['description'] = "Remi's test RPM repository for Enterprise Linux 6 - $basearch"
 else
-  case node['platform_version'].to_i
-  when 5
-    # default['yum']['remi-test']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/remi-test/$basearch/'
-    default['yum']['remi-test']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/5/remi-test/mirror'
-    default['yum']['remi-test']['description'] = "Remi's test RPM repository for Enterprise Linux 5 - $basearch"
-  when 6, 2013, 2014, 2015, 2016
-    # default['yum']['remi-test']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/remi-test/$basearch/'
-    default['yum']['remi-test']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/6/remi-test/mirror'
-    default['yum']['remi-test']['description'] = "Remi's test RPM repository for Enterprise Linux 6 - $basearch"
-  when 7
-    # default['yum']['remi-test']['baseurl'] = 'http://rpms.remirepo.net/enterprise/7/remi-test/$basearch/'
-    default['yum']['remi-test']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/7/remi-test/mirror'
-    default['yum']['remi-test']['description'] = "Remi's test RPM repository for Enterprise Linux 7 - $basearch"
-  end
+  # default['yum']['remi-test']['baseurl'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/remi-test/$basearch/"
+  default['yum']['remi-test']['mirrorlist'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/remi-test/mirror"
+  default['yum']['remi-test']['description'] = "Remi's test RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
 end

--- a/attributes/remi.rb
+++ b/attributes/remi.rb
@@ -9,19 +9,13 @@ when 'fedora'
   # default['yum']['remi']['baseurl'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/remi/$basearch/"
   default['yum']['remi']['mirrorlist'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/remi/mirror"
   default['yum']['remi']['description'] = "Remi's RPM repository for Fedora Linux #{node['platform_version'].to_i} - $basearch"
+when 'amazon'
+  # Default to EL6
+  # default['yum']['remi']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/remi/$basearch/'
+  default['yum']['remi']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/6/remi/mirror'
+  default['yum']['remi']['description'] = "Remi's RPM repository for Enterprise Linux 6 - $basearch"
 else
-  case node['platform_version'].to_i
-  when 5
-    # default['yum']['remi']['baseurl'] = 'http://rpms.remirepo.net/enterprise/5/remi/$basearch/'
-    default['yum']['remi']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/5/remi/mirror'
-    default['yum']['remi']['description'] = "Remi's RPM repository for Enterprise Linux 5 - $basearch"
-  when 6, 2013, 2014, 2015, 2016
-    # default['yum']['remi']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/remi/$basearch/'
-    default['yum']['remi']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/6/remi/mirror'
-    default['yum']['remi']['description'] = "Remi's RPM repository for Enterprise Linux 6 - $basearch"
-  when 7
-    # default['yum']['remi']['baseurl'] = 'http://rpms.remirepo.net/enterprise/7/remi/$basearch/'
-    default['yum']['remi']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/7/remi/mirror'
-    default['yum']['remi']['description'] = "Remi's RPM repository for Enterprise Linux 7 - $basearch"
-  end
+  # default['yum']['remi']['baseurl'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/remi/$basearch/"
+  default['yum']['remi']['mirrorlist'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/remi/mirror"
+  default['yum']['remi']['description'] = "Remi's RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
 end


### PR DESCRIPTION
### Description

Adds Amazon Linux 2016 for remi-php55 and remi-php56-debuginfo. 

### Issues Resolved

Support for Amazon Linux 2016 was overlooked in the 1.2.0 release.

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing. - Existing tests for 2015.09
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD