### PR TITLE
Added the remi-safe repository.

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -56,6 +56,19 @@ suites:
         enabled: true
         managed: true
 
+- name: remi-safe
+  run_list:
+  - recipe[yum-remi-chef::remi-safe]
+  - recipe[test::default]
+  attributes:
+    yum:
+      remi:
+        enabled: true
+        managed: true
+  excludes:
+  - centos-5
+  - fedora-latest
+
 - name: remi-php55
   run_list:
   - recipe[yum-remi-chef::remi-php55]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,6 +26,19 @@ suites:
         enabled: true
         managed: true
 
+- name: remi-safe
+  run_list:
+  - recipe[yum-remi-chef::remi-safe]
+  - recipe[test::default]
+  attributes:
+    yum:
+      remi:
+        enabled: true
+        managed: true
+  excludes:
+  - centos-5.11
+  - fedora-24
+
 - name: remi-php55
   run_list:
   - recipe[yum-remi-chef::remi-php55]

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ env:
   - INSTANCE=remi-centos-6
   - INSTANCE=remi-centos-7
   - INSTANCE=remi-fedora-latest
+  - INSTANCE=remi-safe-centos-6
+  - INSTANCE=remi-safe-centos-7
   - INSTANCE=remi-php55-centos-6
   - INSTANCE=remi-php55-centos-7
   - INSTANCE=remi-php56-centos-6

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # yum-remi-chef Cookbook
 [![Build Status](https://travis-ci.org/chef-cookbooks/yum-remi-chef.svg?branch=master)](http://travis-ci.org/chef-cookbooks/yum-remi-chef) [![Cookbook Version](https://img.shields.io/cookbook/v/yum-remi-chef.svg)](https://supermarket.chef.io/cookbooks/yum-remi-chef)
 
-The yum-remi-chef cookbook takes over management of the repository ids of the [remi](http://rpms.remirepo.net/) repository . It allows attribute manipulation of `remi`, `remi-php55`, `remi-php56`, `remi-php70` and `remi-test` repositories.
+The yum-remi-chef cookbook takes over management of the repository ids of the [remi](http://rpms.remirepo.net/) repository . It allows attribute manipulation of `remi`, `remi-safe`, `remi-php55`, `remi-php56`, `remi-php70`, and `remi-test` repositories.
 
 ## Requirements
 ### Chef
@@ -15,17 +15,17 @@ The yum-remi-chef cookbook takes over management of the repository ids of the [r
 The following platforms have been tested with Test Kitchen:
 
 ```
-|-----------+------+------------+------------+------------|
-|           | remi | remi-php55 | remi-php56 | remi-php70 |
-|-----------+------+------------+------------+------------|
-| centos-5  | X    | X          | X          |            |
-|-----------+------+------------+------------+------------|
-| centos-6  | X    | X          | X          | X          |
-|-----------+------+------------+------------+------------|
-| centos-7  | X    | X          | X          | X          |
-|-----------+------+------------+------------+------------|
-| fedora    | X    |            |            |            |
-|-----------+------+------------+------------+------------|
+|-----------+------+-----------+------------+------------+------------|
+|           | remi | remi-safe | remi-php55 | remi-php56 | remi-php70 |
+|-----------+------+-----------+------------+------------+------------|
+| centos-5  | X    |           | X          | X          |            |
+|-----------+------+-----------+------------+------------+------------|
+| centos-6  | X    | X         | X          | X          | X          |
+|-----------+------+-----------+------------+------------+------------|
+| centos-7  | X    | X         | X          | X          | X          |
+|-----------+------+-----------+------------+------------+------------|
+| fedora    | X    |           |            |            | X          |
+|-----------+------+-----------+------------+------------+------------|
 ```
 
 Amazon Linux is _not_ supported by the Remi repository. Amazon maintains their own PHP packages natively, as php53, php54, php55, php56 and php70.
@@ -42,6 +42,15 @@ default['yum']['remi']['description'] = "Remi's RPM repository for Enterprise Li
 default['yum']['remi']['enabled'] = true
 default['yum']['remi']['gpgcheck'] = true
 default['yum']['remi']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-remi'
+```
+
+```ruby
+default['yum']['remi-safe']['repositoryid'] = 'remi-safe'
+default['yum']['remi-safe']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/5/safe/mirror'
+default['yum']['remi-safe']['description'] = "Safe Remi's RPM repository for Enterprise Linux 5 - $basearch"
+default['yum']['remi-safe']['enabled'] = true
+default['yum']['remi-safe']['gpgcheck'] = true
+default['yum']['remi-safe']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-remi'
 ```
 
 ```ruby

--- a/attributes/remi-safe.rb
+++ b/attributes/remi-safe.rb
@@ -1,0 +1,21 @@
+default['yum']['remi-safe']['repositoryid'] = 'remi-safe'
+default['yum']['remi-safe']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-remi'
+default['yum']['remi-safe']['gpgcheck'] = true
+default['yum']['remi-safe']['enabled'] = true
+default['yum']['remi-safe']['managed'] = true
+
+case node['platform']
+when 'fedora'
+  # default['yum']['remi-safe']['baseurl'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/remi/$basearch/"
+  default['yum']['remi-safe']['mirrorlist'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/safe/mirror"
+  default['yum']['remi-safe']['description'] = "Safe Remi's RPM repository for Fedora Linux #{node['platform_version'].to_i} - $basearch"
+when 'amazon'
+  # Default to EL6
+  # default['yum']['remi-safe']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/remi/$basearch/'
+  default['yum']['remi-safe']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/6/safe/mirror'
+  default['yum']['remi-safe']['description'] = "Safe Remi's RPM repository for Enterprise Linux 6 - $basearch"
+else
+  # default['yum']['rem-safei']['baseurl'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/remi/$basearch/"
+  default['yum']['remi-safe']['mirrorlist'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/safe/mirror"
+  default['yum']['remi-safe']['description'] = "Safe Remi's RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
+end

--- a/recipes/remi-php55.rb
+++ b/recipes/remi-php55.rb
@@ -17,7 +17,12 @@
 # limitations under the License.
 
 include_recipe 'yum-epel' unless node['platform'] == 'fedora'
-include_recipe 'yum-remi-chef::remi'
+
+if node['platform'] != 'fedora' && node['platform_version'].to_i > 5
+  include_recipe 'yum-remi-chef::remi-safe'
+else
+  include_recipe 'yum-remi-chef::remi'
+end
 
 %w(remi-php55 remi-php55-debuginfo).each do |repo|
   next unless node['yum'][repo]['managed']

--- a/recipes/remi-php56.rb
+++ b/recipes/remi-php56.rb
@@ -17,7 +17,12 @@
 # limitations under the License.
 
 include_recipe 'yum-epel' unless node['platform'] == 'fedora'
-include_recipe 'yum-remi-chef::remi'
+
+if node['platform'] != 'fedora' && node['platform_version'].to_i > 5
+  include_recipe 'yum-remi-chef::remi-safe'
+else
+  include_recipe 'yum-remi-chef::remi'
+end
 
 %w(remi-php56 remi-php56-debuginfo).each do |repo|
   next unless node['yum'][repo]['managed']

--- a/recipes/remi-safe.rb
+++ b/recipes/remi-safe.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Sean OMeara (<sean@sean.io>)
-# Recipe:: yum-remi-chef::remi-php70
+# Recipe:: yum-remi-chef::remi-safe
 #
 # Copyright 2015-2016, Chef Software, Inc.
 #
@@ -18,13 +18,7 @@
 
 include_recipe 'yum-epel' unless node['platform'] == 'fedora'
 
-if node['platform'] != 'fedora' && node['platform_version'].to_i > 5
-  include_recipe 'yum-remi-chef::remi-safe'
-else
-  include_recipe 'yum-remi-chef::remi'
-end
-
-%w(remi-php70 remi-php70-debuginfo).each do |repo|
+%w(remi-safe).each do |repo|
   next unless node['yum'][repo]['managed']
 
   yum_repository repo do

--- a/recipes/remi-test.rb
+++ b/recipes/remi-test.rb
@@ -18,6 +18,12 @@
 
 include_recipe 'yum-epel' unless node['platform'] == 'fedora'
 
+if node['platform'] != 'fedora' && node['platform_version'].to_i > 5
+  include_recipe 'yum-remi-chef::remi-safe'
+end
+
+include_recipe 'yum-remi-chef::remi'
+
 %w(remi-test remi-test-debuginfo).each do |repo|
   next unless node['yum'][repo]['managed']
 

--- a/recipes/remi.rb
+++ b/recipes/remi.rb
@@ -18,6 +18,10 @@
 
 include_recipe 'yum-epel' unless node['platform'] == 'fedora'
 
+if node['platform'] != 'fedora' && node['platform_version'].to_i > 5
+  include_recipe 'yum-remi-chef::remi-safe'
+end
+
 %w(remi remi-debuginfo).each do |repo|
   next unless node['yum'][repo]['managed']
 

--- a/spec/amazon_201509_remi_php55_spec.rb
+++ b/spec/amazon_201509_remi_php55_spec.rb
@@ -13,8 +13,8 @@ describe 'yum-remi-chef::remi-php55' do
     end.converge(described_recipe)
   end
 
-  it 'creates yum_repository[remi]' do
-    expect(amazon_2015_remi_php55).to create_yum_repository('remi')
+  it 'creates yum_repository[remi-safe]' do
+    expect(amazon_2015_remi_php55).to create_yum_repository('remi-safe')
   end
 
   %w(

--- a/spec/amazon_201509_remi_php56_spec.rb
+++ b/spec/amazon_201509_remi_php56_spec.rb
@@ -13,8 +13,8 @@ describe 'yum-remi-chef::remi-php56' do
     end.converge(described_recipe)
   end
 
-  it 'creates yum_repository[remi]' do
-    expect(amazon_2015_remi_php56).to create_yum_repository('remi')
+  it 'creates yum_repository[remi-safe]' do
+    expect(amazon_2015_remi_php56).to create_yum_repository('remi-safe')
   end
 
   %w(

--- a/spec/amazon_201509_remi_safe_spec.rb
+++ b/spec/amazon_201509_remi_safe_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe 'yum-remi-chef::remi-safe' do
+  cached(:amazon_2015_remi_safe) do
+    ChefSpec::ServerRunner.new(
+      platform: 'amazon',
+      version: '2015.09'
+    ) do |node|
+      node.normal['yum']['remi-safe']['enabled'] = true
+      node.normal['yum']['remi-safe']['managed'] = true
+    end.converge(described_recipe)
+  end
+
+  %w(
+    remi-safe
+  ).each do |repo|
+    it "creates yum_repository[#{repo}]" do
+      expect(amazon_2015_remi_safe).to create_yum_repository(repo)
+    end
+  end
+end

--- a/spec/centos_65_remi_php55_spec.rb
+++ b/spec/centos_65_remi_php55_spec.rb
@@ -13,8 +13,8 @@ describe 'yum-remi-chef::remi-php55' do
     end.converge(described_recipe)
   end
 
-  it 'creates yum_repository[remi]' do
-    expect(centos_65_remi_php55).to create_yum_repository('remi')
+  it 'creates yum_repository[remi-safe]' do
+    expect(centos_65_remi_php55).to create_yum_repository('remi-safe')
   end
 
   %w(

--- a/spec/centos_65_remi_php56_spec.rb
+++ b/spec/centos_65_remi_php56_spec.rb
@@ -13,8 +13,8 @@ describe 'yum-remi-chef::remi-php56' do
     end.converge(described_recipe)
   end
 
-  it 'creates yum_repository[remi]' do
-    expect(centos_65_remi_php56).to create_yum_repository('remi')
+  it 'creates yum_repository[remi-safe]' do
+    expect(centos_65_remi_php56).to create_yum_repository('remi-safe')
   end
 
   %w(

--- a/spec/centos_65_remi_php70_spec.rb
+++ b/spec/centos_65_remi_php70_spec.rb
@@ -13,8 +13,8 @@ describe 'yum-remi-chef::remi-php70' do
     end.converge(described_recipe)
   end
 
-  it 'creates yum_repository[remi]' do
-    expect(centos_65_remi_php70).to create_yum_repository('remi')
+  it 'creates yum_repository[remi-safe]' do
+    expect(centos_65_remi_php70).to create_yum_repository('remi-safe')
   end
 
   %w(

--- a/spec/centos_65_remi_safe_spec.rb
+++ b/spec/centos_65_remi_safe_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe 'yum-remi-chef::remi-safe' do
+  cached(:centos_65_remi_safe) do
+    ChefSpec::ServerRunner.new(
+      platform: 'centos',
+      version: '6.5'
+    ) do |node|
+      node.normal['yum']['remi-safe']['enabled'] = true
+      node.normal['yum']['remi-safe']['managed'] = true
+    end.converge(described_recipe)
+  end
+
+  %w(
+    remi-safe
+  ).each do |repo|
+    it "creates yum_repository[#{repo}]" do
+      expect(centos_65_remi_safe).to create_yum_repository(repo)
+    end
+  end
+end

--- a/spec/centos_70_remi_php55_spec.rb
+++ b/spec/centos_70_remi_php55_spec.rb
@@ -13,8 +13,8 @@ describe 'yum-remi-chef::remi-php55' do
     end.converge(described_recipe)
   end
 
-  it 'creates yum_repository[remi]' do
-    expect(centos_70_remi_php55).to create_yum_repository('remi')
+  it 'creates yum_repository[remi-safe]' do
+    expect(centos_70_remi_php55).to create_yum_repository('remi-safe')
   end
 
   %w(

--- a/spec/centos_70_remi_php56_spec.rb
+++ b/spec/centos_70_remi_php56_spec.rb
@@ -13,8 +13,8 @@ describe 'yum-remi-chef::remi-php56' do
     end.converge(described_recipe)
   end
 
-  it 'creates yum_repository[remi]' do
-    expect(centos_70_remi_php56).to create_yum_repository('remi')
+  it 'creates yum_repository[remi-safe]' do
+    expect(centos_70_remi_php56).to create_yum_repository('remi-safe')
   end
 
   %w(

--- a/spec/centos_70_remi_php70_spec.rb
+++ b/spec/centos_70_remi_php70_spec.rb
@@ -13,8 +13,8 @@ describe 'yum-remi-chef::remi-php70' do
     end.converge(described_recipe)
   end
 
-  it 'creates yum_repository[remi]' do
-    expect(centos_70_remi_php70).to create_yum_repository('remi')
+  it 'creates yum_repository[remi-safe]' do
+    expect(centos_70_remi_php70).to create_yum_repository('remi-safe')
   end
 
   %w(

--- a/spec/centos_70_remi_safe_spec.rb
+++ b/spec/centos_70_remi_safe_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe 'yum-remi-chef::remi-safe' do
+  cached(:centos_70_remi_safe) do
+    ChefSpec::ServerRunner.new(
+      platform: 'centos',
+      version: '7.0'
+    ) do |node|
+      node.normal['yum']['remi-safe']['enabled'] = true
+      node.normal['yum']['remi-safe']['managed'] = true
+    end.converge(described_recipe)
+  end
+
+  %w(
+    remi-safe
+  ).each do |repo|
+    it "creates yum_repository[#{repo}]" do
+      expect(centos_70_remi_safe).to create_yum_repository(repo)
+    end
+  end
+end

--- a/test/integration/remi-safe/default_spec.rb
+++ b/test/integration/remi-safe/default_spec.rb
@@ -1,0 +1,17 @@
+if os[:family] == 'centos'
+  if os[:release] >= 7
+    describe command('php --version') do
+      its('stdout') { should match(/5.4/) }
+    end
+  else
+    describe command('php --version') do
+      its('stdout') { should match(/5.3/) }
+    end
+  end
+end
+
+if os[:family] == 'fedora'
+  describe command('php --version') do
+    its('stdout') { should match(/5.6/) }
+  end
+end


### PR DESCRIPTION
### Description

This repository is the default on CentOS 6 and 7 and provides non-conflicting packages. It can safely be enabled by default. The remi repository provides PHP 5.4 and should only be enabled on those platforms where the remi-safe repository is unavailable.

### Issues Resolved

No related issues.

### Check List
- [X] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD