### PR TITLE
added support for php 7.3 and removed tests for versions deprecated b…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ env:
   matrix:
   - INSTANCE=remi-centos-6
   - INSTANCE=remi-centos-7
-  - INSTANCE=remi-fedora-28
   - INSTANCE=remi-safe-centos-6
   - INSTANCE=remi-safe-centos-7
   - INSTANCE=remi-php55-centos-6
@@ -30,13 +29,14 @@ env:
   - INSTANCE=remi-php56-centos-7
   - INSTANCE=remi-php70-centos-6
   - INSTANCE=remi-php70-centos-7
-  - INSTANCE=remi-php70-fedora-28
   - INSTANCE=remi-php71-centos-6
   - INSTANCE=remi-php71-centos-7
-  - INSTANCE=remi-php71-fedora-28
   - INSTANCE=remi-php72-centos-6
   - INSTANCE=remi-php72-centos-7
   - INSTANCE=remi-php72-fedora-28
+  - INSTANCE=remi-php73-centos-6
+  - INSTANCE=remi-php73-centos-7
+  - INSTANCE=remi-php73-fedora-28
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )

--- a/README.md
+++ b/README.md
@@ -19,22 +19,24 @@ The yum-remi-chef cookbook takes over management of the repository ids of the [r
 The following platforms have been tested with Test Kitchen:
 
 ```
-|-----------+------+-----------+------------+------------+------------+------------+------------|
-|           | remi | remi-safe | remi-php55 | remi-php56 | remi-php70 | remi-php71 | remi-php72 |
-|-----------+------+-----------+------------+------------+------------+------------+------------|
-| centos-5  | X    |           | X          | X          |            |            |            |
-|-----------+------+-----------+------------+------------+------------+------------+------------|
-| centos-6  | X    | X         | X          | X          | X          | X          | X          |
-|-----------+------+-----------+------------+------------+------------+------------+------------|
-| centos-7  | X    | X         | X          | X          | X          | X          | X          |
-|-----------+------+-----------+------------+------------+------------+------------+------------|
-| fedora    | X    |           |            |            | X          | X          | X          |
-|-----------+------+-----------+------------+------------+------------+------------+------------|
+|-----------+------+------------+------------+------------+------------+------------+------------+------------|
+|           | remi | remi-safe  | remi-php55 | remi-php56 | remi-php70 | remi-php71 | remi-php72 | remi-php73 |
+|-----------+------+------------+------------+------------+------------+------------+------------+------------|
+| centos-5  | X    |            | X          | X          |            |            |            |            |
+|-----------+------+------------+------------+------------+------------+------------+------------+------------|
+| centos-6  | X    | X          | X          | X          | X          | X          | X          | X          |
+|-----------+------+------------+------------+------------+------------+------------+------------+------------|
+| centos-7  | X    | X          | X          | X          | X          | X          | X          | X          |
+|-----------+------+------------+------------+------------+------------+------------+------------+------------|
+| fedora    | X    | NO SUPPORT | NO SUPPORT | NO SUPPORT | NO SUPPORT | NO SUPPORT | X          | X          |
+|-----------+------+------------+------------+------------+------------+------------+------------+------------|
 ```
 
 Amazon Linux is _not_ supported by the Remi repository. Amazon maintains their own PHP packages natively, as php53, php54, php55, php56 and php70.
 
 centos-5 with remi-php70, remi-php71 and remi-php72 is _not_ working currently.
+
+Remirepo does not support php < 7.2 on Fedora.
 
 ## Attributes
 
@@ -104,6 +106,16 @@ default['yum']['remi-php72']['description'] = "Remi's PHP 7.2 RPM repository for
 default['yum']['remi-php72']['enabled'] = true
 default['yum']['remi-php72']['gpgcheck'] = true
 default['yum']['remi-php72']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-remi'
+```
+
+```ruby
+default['yum']['remi-php73']['managed'] = true
+default['yum']['remi-php73']['repositoryid'] = 'remi-php73'
+default['yum']['remi-php73']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/6/php73/mirror'
+default['yum']['remi-php73']['description'] = "Remi's PHP 7.2 RPM repository for Enterprise Linux 6 - $basearch"
+default['yum']['remi-php73']['enabled'] = true
+default['yum']['remi-php73']['gpgcheck'] = true
+default['yum']['remi-php73']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-remi'
 ```
 
 ## Recipes

--- a/attributes/remi-debuginfo.rb
+++ b/attributes/remi-debuginfo.rb
@@ -1,5 +1,4 @@
 default['yum']['remi-debuginfo']['repositoryid'] = 'remi-debuginfo'
-default['yum']['remi-debuginfo']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-remi'
 default['yum']['remi-debuginfo']['gpgcheck'] = true
 default['yum']['remi-debuginfo']['enabled'] = false
 default['yum']['remi-debuginfo']['managed'] = false

--- a/attributes/remi-gpgkey.rb
+++ b/attributes/remi-gpgkey.rb
@@ -1,0 +1,11 @@
+# From https://rpms.remirepo.net/ in the "Other Resources" section about
+# gpg keys for platform versions.
+default['yum-remi-chef']['gpgkey'] = if node['platform'].eql?('fedora') &&
+                                        node['platform_version'].to_i >= 28
+                                       'https://rpms.remirepo.net/RPM-GPG-KEY-remi2018'
+                                     elsif node['platform'].eql?('fedora') &&
+                                           node['platform_version'].to_i.between?(26, 27)
+                                       'https://rpms.remirepo.net/RPM-GPG-KEY-remi2017'
+                                     else
+                                       'https://rpms.remirepo.net/RPM-GPG-KEY-remi'
+                                     end

--- a/attributes/remi-php55-debuginfo.rb
+++ b/attributes/remi-php55-debuginfo.rb
@@ -1,5 +1,4 @@
 default['yum']['remi-php55-debuginfo']['repositoryid'] = 'remi-php55-debuginfo'
-default['yum']['remi-php55-debuginfo']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-remi'
 default['yum']['remi-php55-debuginfo']['gpgcheck'] = true
 default['yum']['remi-php55-debuginfo']['enabled'] = false
 default['yum']['remi-php55-debuginfo']['managed'] = false

--- a/attributes/remi-php55.rb
+++ b/attributes/remi-php55.rb
@@ -1,5 +1,4 @@
 default['yum']['remi-php55']['repositoryid'] = 'remi-php55'
-default['yum']['remi-php55']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-remi'
 default['yum']['remi-php55']['gpgcheck'] = true
 default['yum']['remi-php55']['enabled'] = true
 default['yum']['remi-php55']['managed'] = true

--- a/attributes/remi-php56-debuginfo.rb
+++ b/attributes/remi-php56-debuginfo.rb
@@ -1,5 +1,4 @@
 default['yum']['remi-php56-debuginfo']['repositoryid'] = 'remi-php56-debuginfo'
-default['yum']['remi-php56-debuginfo']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-remi'
 default['yum']['remi-php56-debuginfo']['gpgcheck'] = true
 default['yum']['remi-php56-debuginfo']['enabled'] = false
 default['yum']['remi-php56-debuginfo']['managed'] = false

--- a/attributes/remi-php56.rb
+++ b/attributes/remi-php56.rb
@@ -1,5 +1,4 @@
 default['yum']['remi-php56']['repositoryid'] = 'remi-php56'
-default['yum']['remi-php56']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-remi'
 default['yum']['remi-php56']['gpgcheck'] = true
 default['yum']['remi-php56']['enabled'] = true
 default['yum']['remi-php56']['managed'] = true

--- a/attributes/remi-php70-debuginfo.rb
+++ b/attributes/remi-php70-debuginfo.rb
@@ -1,5 +1,4 @@
 default['yum']['remi-php70-debuginfo']['repositoryid'] = 'remi-php70-debuginfo'
-default['yum']['remi-php70-debuginfo']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-remi'
 default['yum']['remi-php70-debuginfo']['gpgcheck'] = true
 default['yum']['remi-php70-debuginfo']['enabled'] = false
 default['yum']['remi-php70-debuginfo']['managed'] = false

--- a/attributes/remi-php70.rb
+++ b/attributes/remi-php70.rb
@@ -1,5 +1,4 @@
 default['yum']['remi-php70']['repositoryid'] = 'remi-php70'
-default['yum']['remi-php70']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-remi'
 default['yum']['remi-php70']['gpgcheck'] = true
 default['yum']['remi-php70']['enabled'] = true
 default['yum']['remi-php70']['managed'] = true

--- a/attributes/remi-php71-debuginfo.rb
+++ b/attributes/remi-php71-debuginfo.rb
@@ -1,5 +1,4 @@
 default['yum']['remi-php71-debuginfo']['repositoryid'] = 'remi-php71-debuginfo'
-default['yum']['remi-php71-debuginfo']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-remi'
 default['yum']['remi-php71-debuginfo']['gpgcheck'] = true
 default['yum']['remi-php71-debuginfo']['enabled'] = false
 default['yum']['remi-php71-debuginfo']['managed'] = false

--- a/attributes/remi-php71.rb
+++ b/attributes/remi-php71.rb
@@ -1,5 +1,4 @@
 default['yum']['remi-php71']['repositoryid'] = 'remi-php71'
-default['yum']['remi-php71']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-remi'
 default['yum']['remi-php71']['gpgcheck'] = true
 default['yum']['remi-php71']['enabled'] = true
 default['yum']['remi-php71']['managed'] = true

--- a/attributes/remi-php72-debuginfo.rb
+++ b/attributes/remi-php72-debuginfo.rb
@@ -1,5 +1,4 @@
 default['yum']['remi-php72-debuginfo']['repositoryid'] = 'remi-php72-debuginfo'
-default['yum']['remi-php72-debuginfo']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-remi'
 default['yum']['remi-php72-debuginfo']['gpgcheck'] = true
 default['yum']['remi-php72-debuginfo']['enabled'] = false
 default['yum']['remi-php72-debuginfo']['managed'] = false

--- a/attributes/remi-php72.rb
+++ b/attributes/remi-php72.rb
@@ -1,5 +1,4 @@
 default['yum']['remi-php72']['repositoryid'] = 'remi-php72'
-default['yum']['remi-php72']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-remi'
 default['yum']['remi-php72']['gpgcheck'] = true
 default['yum']['remi-php72']['enabled'] = true
 default['yum']['remi-php72']['managed'] = true

--- a/attributes/remi-php73-debuginfo.rb
+++ b/attributes/remi-php73-debuginfo.rb
@@ -1,0 +1,17 @@
+default['yum']['remi-php73-debuginfo']['repositoryid'] = 'remi-php73-debuginfo'
+default['yum']['remi-php73-debuginfo']['gpgcheck'] = true
+default['yum']['remi-php73-debuginfo']['enabled'] = false
+default['yum']['remi-php73-debuginfo']['managed'] = false
+
+case node['platform']
+when 'fedora'
+  default['yum']['remi-php73-debuginfo']['baseurl'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/debug-php73/$basearch/"
+  default['yum']['remi-php73-debuginfo']['description'] = "Remi's PHP 7.3 RPM repository for Fedora Linux #{node['platform_version'].to_i} - $basearch - debuginfo"
+when 'amazon'
+  # Default to EL6
+  default['yum']['remi-php73-debuginfo']['baseurl'] = 'http://rpms.remirepo.net/enterprise/6/debug-php73/$basearch/'
+  default['yum']['remi-php73-debuginfo']['description'] = "Remi's PHP 7.3 RPM repository for Enterprise Linux 6 - $basearch - debuginfo"
+else
+  default['yum']['remi-php73-debuginfo']['baseurl'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/debug-php73/$basearch/"
+  default['yum']['remi-php73-debuginfo']['description'] = "Remi's PHP 7.3 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch - debuginfo"
+end

--- a/attributes/remi-php73.rb
+++ b/attributes/remi-php73.rb
@@ -1,0 +1,19 @@
+default['yum']['remi-php73']['repositoryid'] = 'remi-php73'
+default['yum']['remi-php73']['gpgcheck'] = true
+default['yum']['remi-php73']['enabled'] = true
+default['yum']['remi-php73']['managed'] = true
+
+case node['platform']
+when 'fedora'
+
+  default['yum']['remi-php73']['mirrorlist'] = "http://rpms.remirepo.net/fedora/#{node['platform_version'].to_i}/php73/mirror"
+  default['yum']['remi-php73']['description'] = "Remi's PHP 7.3 RPM repository for Fedora Linux #{node['platform_version'].to_i} - $basearch"
+when 'amazon'
+
+  default['yum']['remi-php73']['mirrorlist'] = 'http://rpms.remirepo.net/enterprise/6/php73/mirror'
+  default['yum']['remi-php73']['description'] = "Remi's PHP 7.3 RPM repository for Enterprise Linux 6 - $basearch"
+else
+
+  default['yum']['remi-php73']['mirrorlist'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/php73/mirror"
+  default['yum']['remi-php73']['description'] = "Remi's PHP 7.3 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
+end

--- a/attributes/remi-safe.rb
+++ b/attributes/remi-safe.rb
@@ -1,5 +1,4 @@
 default['yum']['remi-safe']['repositoryid'] = 'remi-safe'
-default['yum']['remi-safe']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-remi'
 default['yum']['remi-safe']['gpgcheck'] = true
 default['yum']['remi-safe']['enabled'] = true
 default['yum']['remi-safe']['managed'] = true

--- a/attributes/remi-test-debuginfo.rb
+++ b/attributes/remi-test-debuginfo.rb
@@ -1,5 +1,4 @@
 default['yum']['remi-test']['repositoryid'] = 'remi'
-default['yum']['remi-test']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-remi'
 default['yum']['remi-test']['gpgcheck'] = true
 default['yum']['remi-test']['enabled'] = false
 default['yum']['remi-test']['managed'] = false

--- a/attributes/remi-test.rb
+++ b/attributes/remi-test.rb
@@ -1,5 +1,4 @@
 default['yum']['remi-test']['repositoryid'] = 'remi'
-default['yum']['remi-test']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-remi'
 default['yum']['remi-test']['gpgcheck'] = true
 default['yum']['remi-test']['enabled'] = false
 default['yum']['remi-test']['managed'] = false

--- a/attributes/remi.rb
+++ b/attributes/remi.rb
@@ -1,5 +1,4 @@
 default['yum']['remi']['repositoryid'] = 'remi'
-default['yum']['remi']['gpgkey'] = 'http://rpms.remirepo.net/RPM-GPG-KEY-remi'
 default['yum']['remi']['gpgcheck'] = true
 default['yum']['remi']['enabled'] = true
 default['yum']['remi']['managed'] = true

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -32,7 +32,7 @@ platforms:
 
 - name: fedora-28
   driver:
-    image: fedora:24
+    image: fedora:28
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
       - RUN dnf -y install which net-tools chkconfig passwd

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -47,6 +47,8 @@ suites:
       remi:
         enabled: true
         managed: true
+  excludes:
+  - fedora-28
 
 - name: remi-safe
   run_list:
@@ -58,8 +60,7 @@ suites:
         enabled: true
         managed: true
   excludes:
-  - centos-5
-  - fedora-latest
+  - fedora-28
 
 - name: remi-php55
   run_list:
@@ -74,7 +75,7 @@ suites:
         enabled: true
         managed: true
   excludes:
-  - fedora-latest
+  - fedora-28
 
 - name: remi-php56
   run_list:
@@ -89,7 +90,7 @@ suites:
         enabled: true
         managed: true
   excludes:
-  - fedora-latest
+  - fedora-28
 
 - name: remi-php70
   run_list:
@@ -104,7 +105,7 @@ suites:
         enabled: true
         managed: true
   excludes:
-  - centos-5
+  - fedora-28
 
 - name: remi-php71
   run_list:
@@ -119,7 +120,7 @@ suites:
         enabled: true
         managed: true
   excludes:
-  - centos-5
+  - fedora-28
 
 - name: remi-php72
   run_list:
@@ -133,5 +134,16 @@ suites:
       remi-php72:
         enabled: true
         managed: true
-  excludes:
-  - centos-5
+
+- name: remi-php73
+  run_list:
+  - recipe[yum-remi-chef::remi-php73]
+  - recipe[test::default]
+  attributes:
+    yum:
+      remi:
+        enabled: true
+        managed: true
+      remi-php73:
+        enabled: true
+        managed: true

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -23,6 +23,8 @@ suites:
       remi:
         enabled: true
         managed: true
+  excludes:
+  - fedora-28
 
 - name: remi-safe
   run_list:
@@ -78,6 +80,8 @@ suites:
       remi-php70:
         enabled: true
         managed: true
+  excludes:
+  - fedora-28
 
 - name: remi-php71
   run_list:
@@ -91,6 +95,8 @@ suites:
       remi-php71:
         enabled: true
         managed: true
+  excludes:
+  - fedora-28
 
 - name: remi-php72
   run_list:
@@ -102,5 +108,18 @@ suites:
         enabled: true
         managed: true
       remi-php72:
+        enabled: true
+        managed: true
+
+- name: remi-php73
+  run_list:
+  - recipe[yum-remi-chef::remi-php73]
+  - recipe[test::default]
+  attributes:
+    yum:
+      remi:
+        enabled: true
+        managed: true
+      remi-php73:
         enabled: true
         managed: true

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description "Installs and configures the Remi's yum repository"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '3.0.0'
+version '3.1.0'
 
 depends 'yum-epel'
 

--- a/recipes/remi-php55.rb
+++ b/recipes/remi-php55.rb
@@ -39,7 +39,7 @@ end
     failovermethod node['yum'][repo]['failovermethod'] unless node['yum'][repo]['failovermethod'].nil?
     fastestmirror_enabled node['yum'][repo]['fastestmirror_enabled'] unless node['yum'][repo]['fastestmirror_enabled'].nil?
     gpgcheck node['yum'][repo]['gpgcheck'] unless node['yum'][repo]['gpgcheck'].nil?
-    gpgkey node['yum'][repo]['gpgkey'] unless node['yum'][repo]['gpgkey'].nil?
+    gpgkey node['yum-remi-chef']['gpgkey'] unless node['yum-remi-chef']['gpgkey'].nil?
     http_caching node['yum'][repo]['http_caching'] unless node['yum'][repo]['http_caching'].nil?
     include_config node['yum'][repo]['include_config'] unless node['yum'][repo]['include_config'].nil?
     includepkgs node['yum'][repo]['includepkgs'] unless node['yum'][repo]['includepkgs'].nil?

--- a/recipes/remi-php56.rb
+++ b/recipes/remi-php56.rb
@@ -39,7 +39,7 @@ end
     failovermethod node['yum'][repo]['failovermethod'] unless node['yum'][repo]['failovermethod'].nil?
     fastestmirror_enabled node['yum'][repo]['fastestmirror_enabled'] unless node['yum'][repo]['fastestmirror_enabled'].nil?
     gpgcheck node['yum'][repo]['gpgcheck'] unless node['yum'][repo]['gpgcheck'].nil?
-    gpgkey node['yum'][repo]['gpgkey'] unless node['yum'][repo]['gpgkey'].nil?
+    gpgkey node['yum-remi-chef']['gpgkey'] unless node['yum-remi-chef']['gpgkey'].nil?
     http_caching node['yum'][repo]['http_caching'] unless node['yum'][repo]['http_caching'].nil?
     include_config node['yum'][repo]['include_config'] unless node['yum'][repo]['include_config'].nil?
     includepkgs node['yum'][repo]['includepkgs'] unless node['yum'][repo]['includepkgs'].nil?

--- a/recipes/remi-php70.rb
+++ b/recipes/remi-php70.rb
@@ -39,7 +39,7 @@ end
     failovermethod node['yum'][repo]['failovermethod'] unless node['yum'][repo]['failovermethod'].nil?
     fastestmirror_enabled node['yum'][repo]['fastestmirror_enabled'] unless node['yum'][repo]['fastestmirror_enabled'].nil?
     gpgcheck node['yum'][repo]['gpgcheck'] unless node['yum'][repo]['gpgcheck'].nil?
-    gpgkey node['yum'][repo]['gpgkey'] unless node['yum'][repo]['gpgkey'].nil?
+    gpgkey node['yum-remi-chef']['gpgkey'] unless node['yum-remi-chef']['gpgkey'].nil?
     http_caching node['yum'][repo]['http_caching'] unless node['yum'][repo]['http_caching'].nil?
     include_config node['yum'][repo]['include_config'] unless node['yum'][repo]['include_config'].nil?
     includepkgs node['yum'][repo]['includepkgs'] unless node['yum'][repo]['includepkgs'].nil?

--- a/recipes/remi-php71.rb
+++ b/recipes/remi-php71.rb
@@ -39,7 +39,7 @@ end
     failovermethod node['yum'][repo]['failovermethod'] unless node['yum'][repo]['failovermethod'].nil?
     fastestmirror_enabled node['yum'][repo]['fastestmirror_enabled'] unless node['yum'][repo]['fastestmirror_enabled'].nil?
     gpgcheck node['yum'][repo]['gpgcheck'] unless node['yum'][repo]['gpgcheck'].nil?
-    gpgkey node['yum'][repo]['gpgkey'] unless node['yum'][repo]['gpgkey'].nil?
+    gpgkey node['yum-remi-chef']['gpgkey'] unless node['yum-remi-chef']['gpgkey'].nil?
     http_caching node['yum'][repo]['http_caching'] unless node['yum'][repo]['http_caching'].nil?
     include_config node['yum'][repo]['include_config'] unless node['yum'][repo]['include_config'].nil?
     includepkgs node['yum'][repo]['includepkgs'] unless node['yum'][repo]['includepkgs'].nil?

--- a/recipes/remi-php72.rb
+++ b/recipes/remi-php72.rb
@@ -39,7 +39,7 @@ end
     failovermethod node['yum'][repo]['failovermethod'] unless node['yum'][repo]['failovermethod'].nil?
     fastestmirror_enabled node['yum'][repo]['fastestmirror_enabled'] unless node['yum'][repo]['fastestmirror_enabled'].nil?
     gpgcheck node['yum'][repo]['gpgcheck'] unless node['yum'][repo]['gpgcheck'].nil?
-    gpgkey node['yum'][repo]['gpgkey'] unless node['yum'][repo]['gpgkey'].nil?
+    gpgkey node['yum-remi-chef']['gpgkey'] unless node['yum-remi-chef']['gpgkey'].nil?
     http_caching node['yum'][repo]['http_caching'] unless node['yum'][repo]['http_caching'].nil?
     include_config node['yum'][repo]['include_config'] unless node['yum'][repo]['include_config'].nil?
     includepkgs node['yum'][repo]['includepkgs'] unless node['yum'][repo]['includepkgs'].nil?

--- a/recipes/remi-php73.rb
+++ b/recipes/remi-php73.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Sean OMeara (<sean@sean.io>)
-# Recipe:: yum-remi-chef::remi
+# Recipe:: yum-remi-chef::remi-php73
 #
 # Copyright:: 2015-2017, Chef Software, Inc.
 #
@@ -18,12 +18,15 @@
 
 unless node['platform'] == 'fedora'
   include_recipe 'yum-epel'
-  include_recipe 'yum-remi-chef::remi-safe' if node['platform_version'].to_i > 5
+
+  if node['platform_version'].to_i > 5
+    include_recipe 'yum-remi-chef::remi-safe'
+  else
+    include_recipe 'yum-remi-chef::remi'
+  end
 end
 
-include_recipe 'yum-remi-chef::remi'
-
-%w(remi-test remi-test-debuginfo).each do |repo|
+%w(remi-php73 remi-php73-debuginfo).each do |repo|
   next unless node['yum'][repo]['managed']
 
   yum_repository repo do

--- a/recipes/remi-safe.rb
+++ b/recipes/remi-safe.rb
@@ -31,7 +31,7 @@ include_recipe 'yum-epel' unless node['platform'] == 'fedora'
     failovermethod node['yum'][repo]['failovermethod'] unless node['yum'][repo]['failovermethod'].nil?
     fastestmirror_enabled node['yum'][repo]['fastestmirror_enabled'] unless node['yum'][repo]['fastestmirror_enabled'].nil?
     gpgcheck node['yum'][repo]['gpgcheck'] unless node['yum'][repo]['gpgcheck'].nil?
-    gpgkey node['yum'][repo]['gpgkey'] unless node['yum'][repo]['gpgkey'].nil?
+    gpgkey node['yum-remi-chef']['gpgkey'] unless node['yum-remi-chef']['gpgkey'].nil?
     http_caching node['yum'][repo]['http_caching'] unless node['yum'][repo]['http_caching'].nil?
     include_config node['yum'][repo]['include_config'] unless node['yum'][repo]['include_config'].nil?
     includepkgs node['yum'][repo]['includepkgs'] unless node['yum'][repo]['includepkgs'].nil?

--- a/recipes/remi.rb
+++ b/recipes/remi.rb
@@ -34,7 +34,7 @@ end
     failovermethod node['yum'][repo]['failovermethod'] unless node['yum'][repo]['failovermethod'].nil?
     fastestmirror_enabled node['yum'][repo]['fastestmirror_enabled'] unless node['yum'][repo]['fastestmirror_enabled'].nil?
     gpgcheck node['yum'][repo]['gpgcheck'] unless node['yum'][repo]['gpgcheck'].nil?
-    gpgkey node['yum'][repo]['gpgkey'] unless node['yum'][repo]['gpgkey'].nil?
+    gpgkey node['yum-remi-chef']['gpgkey'] unless node['yum-remi-chef']['gpgkey'].nil?
     http_caching node['yum'][repo]['http_caching'] unless node['yum'][repo]['http_caching'].nil?
     include_config node['yum'][repo]['include_config'] unless node['yum'][repo]['include_config'].nil?
     includepkgs node['yum'][repo]['includepkgs'] unless node['yum'][repo]['includepkgs'].nil?

--- a/spec/centos_6_remi_php73_spec.rb
+++ b/spec/centos_6_remi_php73_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'yum-remi-chef::remi-php73' do
+  cached(:centos_6_remi_php73) do
+    ChefSpec::SoloRunner.new(
+      platform: 'centos',
+      version: '6.9'
+    ) do |node|
+      node.override['yum']['remi-php73']['enabled'] = true
+      node.override['yum']['remi-php73']['managed'] = true
+      node.override['yum']['remi-php73-debuginfo']['enabled'] = true
+      node.override['yum']['remi-php73-debuginfo']['managed'] = true
+    end.converge(described_recipe)
+  end
+
+  it 'creates yum_repository[remi-safe]' do
+    expect(centos_6_remi_php73).to create_yum_repository('remi-safe')
+  end
+
+  %w(
+    remi-php73
+    remi-php73-debuginfo
+  ).each do |repo|
+    it "creates yum_repository[#{repo}]" do
+      expect(centos_6_remi_php73).to create_yum_repository(repo)
+    end
+  end
+end

--- a/spec/centos_7_remi_php73_spec.rb
+++ b/spec/centos_7_remi_php73_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'yum-remi-chef::remi-php73' do
+  cached(:centos_7_remi_php73) do
+    ChefSpec::SoloRunner.new(
+      platform: 'centos',
+      version: '7.3.1611'
+    ) do |node|
+      node.override['yum']['remi-php73']['enabled'] = true
+      node.override['yum']['remi-php73']['managed'] = true
+      node.override['yum']['remi-php73-debuginfo']['enabled'] = true
+      node.override['yum']['remi-php73-debuginfo']['managed'] = true
+    end.converge(described_recipe)
+  end
+
+  it 'creates yum_repository[remi-safe]' do
+    expect(centos_7_remi_php73).to create_yum_repository('remi-safe')
+  end
+
+  %w(
+    remi-php73
+    remi-php73-debuginfo
+  ).each do |repo|
+    it "creates yum_repository[#{repo}]" do
+      expect(centos_7_remi_php73).to create_yum_repository(repo)
+    end
+  end
+end

--- a/test/integration/remi-php73/default_spec.rb
+++ b/test/integration/remi-php73/default_spec.rb
@@ -1,0 +1,3 @@
+describe command('php --version') do
+  its('stdout') { should match /7.3/ }
+end

--- a/test/integration/remi-safe/default_spec.rb
+++ b/test/integration/remi-safe/default_spec.rb
@@ -1,5 +1,5 @@
-if os[:family] == 'centos'
-  if os[:release] >= 7
+if os[:family] == 'redhat'
+  if os[:release].to_i >= 7
     describe command('php --version') do
       its('stdout') { should match(/5.4/) }
     end

--- a/test/integration/remi/default_spec.rb
+++ b/test/integration/remi/default_spec.rb
@@ -1,4 +1,4 @@
-if os[:family] == 'centos'
+if os[:family] == 'redhat'
   describe command('php --version') do
     its('stdout') { should match /5.4/ }
   end


### PR DESCRIPTION
…y remi

### Description

Adds support for remi's php 7.3 and fixes broken gpgkey URL which is different for various versions of PHP on different platforms.

Also fixes/removes some tests which were broken since remi doesn't support php 7.1 or lower on Fedora.  The README.md has been updated accordingly.

Addresses an testing issue where integration tests were not being run for `remi` and `remi-safe` recipes due to an incorrect test case of `os[:family]` and `os[:release]`.

### Issues Resolved

#20

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
