### PR TITLE
chore: migrate dependency resolution to Policyfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: actionshub/chef-install@main
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,15 @@
-# Limitations
+# AGENTS.md
+
+## Cookbook Purpose
+
+Installs and configures the Remi\
+
+## Agent Findings
+
+* This cookbook is in an incremental modernization pass. Preserve existing public recipes and attributes unless a later full migration is explicitly selected.
+* Dependency management should use `Policyfile.rb`; do not reintroduce Berkshelf.
+
+## Known Limitations
 
 This cookbook manages Remi RPM repositories and PHP module streams through custom
 resources.

--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-cookbook 'test', path: 'test/cookbooks/test'

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+name 'yum-remi-chef'
+
+run_list 'test::default'
+
+cookbook 'yum-remi-chef', path: '.'
+cookbook 'yum', git: 'https://github.com/sous-chefs/yum.git', branch: 'main'
+cookbook 'yum-epel', git: 'https://github.com/sous-chefs/yum-epel.git', branch: 'main'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+end

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Remi currently publishes maintained repositories for Enterprise Linux 8, 9, and 
 
 `M` indicates the cookbook enables the matching `php:remi-*` DNF module stream.
 
-For upstream package and platform notes, see [LIMITATIONS.md](LIMITATIONS.md).
+For upstream package and platform notes, see [AGENTS.md](AGENTS.md).
 
 ## Migration
 

--- a/chefignore
+++ b/chefignore
@@ -83,10 +83,7 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
 #############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -109,18 +109,26 @@ suites:
     verifier: *default_verifier
 
   - name: remi
+    provisioner:
+      named_run_list: remi
     run_list: *remi_run_list
     verifier: *remi_verifier
 
   - name: remi-test
+    provisioner:
+      named_run_list: remi_test
     run_list: *remi_test_run_list
     verifier: *remi_test_verifier
 
   - name: remi-modular
+    provisioner:
+      named_run_list: remi_modular
     run_list: *remi_modular_run_list
     verifier: *remi_modular_verifier
 
   - name: remi-php72
+    provisioner:
+      named_run_list: remi_php72
     run_list: *remi_php72_run_list
     verifier: *remi_php72_verifier
     excludes:
@@ -131,6 +139,8 @@ suites:
       - rockylinux-9
 
   - name: remi-php73
+    provisioner:
+      named_run_list: remi_php73
     run_list: *remi_php73_run_list
     verifier: *remi_php73_verifier
     excludes:
@@ -141,25 +151,37 @@ suites:
       - rockylinux-9
 
   - name: remi-php74
+    provisioner:
+      named_run_list: remi_php74
     run_list: *remi_php74_run_list
     verifier: *remi_php74_verifier
 
   - name: remi-php80
+    provisioner:
+      named_run_list: remi_php80
     run_list: *remi_php80_run_list
     verifier: *remi_php80_verifier
 
   - name: remi-php81
+    provisioner:
+      named_run_list: remi_php81
     run_list: *remi_php81_run_list
     verifier: *remi_php81_verifier
 
   - name: remi-php82
+    provisioner:
+      named_run_list: remi_php82
     run_list: *remi_php82_run_list
     verifier: *remi_php82_verifier
 
   - name: remi-php83
+    provisioner:
+      named_run_list: remi_php83
     run_list: *remi_php83_run_list
     verifier: *remi_php83_verifier
 
   - name: remi-php84
+    provisioner:
+      named_run_list: remi_php84
     run_list: *remi_php84_run_list
     verifier: *remi_php84_verifier

--- a/resources/remi_safe.rb
+++ b/resources/remi_safe.rb
@@ -20,7 +20,9 @@ end
 action :create do
   validate_remi_platform!
 
-  include_recipe 'yum-epel' if new_resource.manage_epel
+  yum_epel 'default' do
+    only_if { new_resource.manage_epel }
+  end
 
   yum_repository 'remi-safe' do
     baseurl new_resource.baseurl

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Summary
- migrate dependency resolution from Berksfile to Policyfile
- update ChefSpec setup to use Policyfile resolution
- update Copilot setup to install Chef Workstation 8.0.4 and run chef install Policyfile.rb
- move cookbook limitations into AGENTS.md where present

## Verification
- chef install Policyfile.rb
- cookstyle
- kitchen list
- /opt/chef-workstation/embedded/bin/rspec --format progress